### PR TITLE
International Currency Parsing Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.4</version>
+    <version>3.6.4.3-dev</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -32,6 +32,14 @@
         <repository>
             <id>codemc-repo</id>
             <url>https://repo.codemc.org/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo</url>
+        </repository>
+        <repository>
+            <id>essentials</id>
+            <url>https://repo.essentialsx.net/releases/</url>
         </repository>
     </repositories>
     <dependencies>
@@ -60,14 +68,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sk89q.worldguard.bukkit</groupId>
-            <artifactId>worldguard</artifactId>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
             <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sk89q.worldedit.bukkit</groupId>
-            <artifactId>worldedit</artifactId>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-bukkit</artifactId>
             <version>7.1.0</version>
             <scope>provided</scope>
         </dependency>
@@ -90,9 +98,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.earth2me</groupId>
-            <artifactId>essentials</artifactId>
-            <version>2.17.1.0</version>
+            <groupId>net.ess3</groupId>
+            <artifactId>EssentialsX</artifactId>
+            <version>2.17.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -122,7 +130,7 @@
         <dependency>
             <groupId>nl.rutgerkok</groupId>
             <artifactId>blocklocker</artifactId>
-            <version>0.1</version>
+            <version>1.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/wargamer2010/signshop/SignShop.java
+++ b/src/main/java/org/wargamer2010/signshop/SignShop.java
@@ -153,6 +153,21 @@ public class SignShop extends JavaPlugin {
         store = Storage.init(new File(this.getDataFolder(), "sellers.yml"));
         manager = new TimeManager(new File(this.getDataFolder(), "timing.yml"));
 
+        if (SignShopConfig.allowCommaDecimalSeparator() == SignShopConfig.CommaDecimalSeparatorState.AUTO) {
+            // Plugin must decide if the comma separators are enabled
+            SignShopConfig.CommaDecimalSeparatorState state;
+            String logMessage;
+            if (store.shopCount() == 0) {
+                logMessage = "Comma decimal seperators have been enabled because this server has 0 shops";
+                state = SignShopConfig.CommaDecimalSeparatorState.TRUE;
+            } else {
+                logMessage = "Comma decimal seperators have been disabled because this server has " + store.shopCount() + " shop(s) that may not be compatible with the new parser";
+                state = SignShopConfig.CommaDecimalSeparatorState.FALSE;
+            }
+            log(logMessage + ". This can be changed by modifying 'AllowCommaDecimalSeperators' in the config.", Level.INFO);
+            SignShopConfig.setAllowCommaDecimalSeparator(state);
+        }
+
         if (SignShopConfig.getTransactionLog()) {
             try {
                 FileHandler fh = new FileHandler("plugins/SignShop/Transaction.log", true);

--- a/src/main/java/org/wargamer2010/signshop/SignShop.java
+++ b/src/main/java/org/wargamer2010/signshop/SignShop.java
@@ -161,7 +161,7 @@ public class SignShop extends JavaPlugin {
                 logMessage = "Comma decimal seperators have been enabled because this server has 0 shops";
                 state = SignShopConfig.CommaDecimalSeparatorState.TRUE;
             } else {
-                logMessage = "Comma decimal seperators have been disabled because this server has " + store.shopCount() + " shop(s) that may not be compatible with the new parser";
+                logMessage = "Comma decimal separators have been disabled because this server has " + store.shopCount() + " shop(s) that may not be compatible with the new parser";
                 state = SignShopConfig.CommaDecimalSeparatorState.FALSE;
             }
             log(logMessage + ". This can be changed by modifying 'AllowCommaDecimalSeperators' in the config.", Level.INFO);

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -69,6 +69,7 @@ public class SignShopConfig {
     private static boolean EnableAutomaticLock = false;
     private static boolean UseBlacklistAsWhitelist = false;
     private static boolean EnableWrittenBookFix = true;
+    private static boolean UseInternationalCurrencyParser = false;
     private static String ColorCode = "&";
     private static String ChatPrefix = "&6[SignShop]";
     private static ChatColor TextColor = ChatColor.YELLOW;
@@ -243,6 +244,7 @@ public class SignShopConfig {
         EnableAutomaticLock = ymlThing.getBoolean("EnableAutomaticLock", EnableAutomaticLock);
         UseBlacklistAsWhitelist = ymlThing.getBoolean("UseBlacklistAsWhitelist", UseBlacklistAsWhitelist);
         EnableWrittenBookFix = ymlThing.getBoolean("EnableWrittenBookFix", EnableWrittenBookFix);
+        UseInternationalCurrencyParser = ymlThing.getBoolean("UseInternationalCurrencyParser", UseInternationalCurrencyParser);
         ColorCode = ymlThing.getString("ColorCode", ColorCode);
         ChatPrefix = ymlThing.getString("ChatPrefix", ChatPrefix);
         Languages = ymlThing.getString("Languages", Languages);
@@ -811,6 +813,8 @@ public class SignShopConfig {
     public static boolean isInspectionMaterial(ItemStack item) {
         return (item !=null && item.getType() == inspectMaterial);
     }
+
+    public static boolean useInternationalCurrencyParser() { return UseInternationalCurrencyParser; }
 
     public static Material getLinkMaterial() {
         return linkMaterial;

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -69,7 +69,7 @@ public class SignShopConfig {
     private static boolean EnableAutomaticLock = false;
     private static boolean UseBlacklistAsWhitelist = false;
     private static boolean EnableWrittenBookFix = true;
-    private static boolean UseInternationalCurrencyParser = false;
+    private static boolean AllowCommaDecimalSeperator = false;
     private static String ColorCode = "&";
     private static String ChatPrefix = "&6[SignShop]";
     private static ChatColor TextColor = ChatColor.YELLOW;
@@ -244,7 +244,7 @@ public class SignShopConfig {
         EnableAutomaticLock = ymlThing.getBoolean("EnableAutomaticLock", EnableAutomaticLock);
         UseBlacklistAsWhitelist = ymlThing.getBoolean("UseBlacklistAsWhitelist", UseBlacklistAsWhitelist);
         EnableWrittenBookFix = ymlThing.getBoolean("EnableWrittenBookFix", EnableWrittenBookFix);
-        UseInternationalCurrencyParser = ymlThing.getBoolean("UseInternationalCurrencyParser", UseInternationalCurrencyParser);
+        AllowCommaDecimalSeperator = ymlThing.getBoolean("AllowCommaDecimalSeperator", AllowCommaDecimalSeperator);
         ColorCode = ymlThing.getString("ColorCode", ColorCode);
         ChatPrefix = ymlThing.getString("ChatPrefix", ChatPrefix);
         Languages = ymlThing.getString("Languages", Languages);
@@ -814,7 +814,7 @@ public class SignShopConfig {
         return (item !=null && item.getType() == inspectMaterial);
     }
 
-    public static boolean useInternationalCurrencyParser() { return UseInternationalCurrencyParser; }
+    public static boolean allowCommaDecimalSeperator() { return AllowCommaDecimalSeperator; }
 
     public static Material getLinkMaterial() {
         return linkMaterial;

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -244,7 +244,7 @@ public class SignShopConfig {
         EnableAutomaticLock = ymlThing.getBoolean("EnableAutomaticLock", EnableAutomaticLock);
         UseBlacklistAsWhitelist = ymlThing.getBoolean("UseBlacklistAsWhitelist", UseBlacklistAsWhitelist);
         EnableWrittenBookFix = ymlThing.getBoolean("EnableWrittenBookFix", EnableWrittenBookFix);
-        setAllowCommaDecimalSeparator(CommaDecimalSeparatorState.fromName(ymlThing.getString("AllowCommaDecimalSeparator", CommaDecimalSeparatorState.AUTO.name)));
+        setAllowCommaDecimalSeparator(CommaDecimalSeparatorState.fromName(ymlThing.getString("AllowCommaDecimalSeparator", AllowCommaDecimalSeparator.name)));
         ColorCode = ymlThing.getString("ColorCode", ColorCode);
         ChatPrefix = ymlThing.getString("ChatPrefix", ChatPrefix);
         Languages = ymlThing.getString("Languages", Languages);

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -69,7 +69,7 @@ public class SignShopConfig {
     private static boolean EnableAutomaticLock = false;
     private static boolean UseBlacklistAsWhitelist = false;
     private static boolean EnableWrittenBookFix = true;
-    private static boolean AllowCommaDecimalSeperator = false;
+    private static CommaDecimalSeparatorState AllowCommaDecimalSeparator = CommaDecimalSeparatorState.AUTO;
     private static String ColorCode = "&";
     private static String ChatPrefix = "&6[SignShop]";
     private static ChatColor TextColor = ChatColor.YELLOW;
@@ -244,7 +244,7 @@ public class SignShopConfig {
         EnableAutomaticLock = ymlThing.getBoolean("EnableAutomaticLock", EnableAutomaticLock);
         UseBlacklistAsWhitelist = ymlThing.getBoolean("UseBlacklistAsWhitelist", UseBlacklistAsWhitelist);
         EnableWrittenBookFix = ymlThing.getBoolean("EnableWrittenBookFix", EnableWrittenBookFix);
-        AllowCommaDecimalSeperator = ymlThing.getBoolean("AllowCommaDecimalSeperator", AllowCommaDecimalSeperator);
+        setAllowCommaDecimalSeparator(CommaDecimalSeparatorState.fromName(ymlThing.getString("AllowCommaDecimalSeparator", CommaDecimalSeparatorState.AUTO.name)));
         ColorCode = ymlThing.getString("ColorCode", ColorCode);
         ChatPrefix = ymlThing.getString("ChatPrefix", ChatPrefix);
         Languages = ymlThing.getString("Languages", Languages);
@@ -814,7 +814,45 @@ public class SignShopConfig {
         return (item !=null && item.getType() == inspectMaterial);
     }
 
-    public static boolean allowCommaDecimalSeperator() { return AllowCommaDecimalSeperator; }
+    public enum CommaDecimalSeparatorState {
+        AUTO("auto", false),
+        FALSE("false", false),
+        TRUE("true", true);
+
+        private final String name;
+        private final boolean permitted;
+        public String getName() { return name; }
+        public boolean isPermitted() { return permitted; }
+
+        public static CommaDecimalSeparatorState fromName(String name) {
+            for (CommaDecimalSeparatorState state : CommaDecimalSeparatorState.values()) {
+                if (state.name.equalsIgnoreCase(name)) return state;
+            }
+
+            return CommaDecimalSeparatorState.AUTO;
+        }
+
+        CommaDecimalSeparatorState(String name, boolean permitted) {
+            this.name = name;
+            this.permitted = permitted;
+        }
+    }
+
+    public static CommaDecimalSeparatorState allowCommaDecimalSeparator() { return AllowCommaDecimalSeparator; }
+    public static void setAllowCommaDecimalSeparator(CommaDecimalSeparatorState state, boolean doSave) {
+        AllowCommaDecimalSeparator = state;
+
+        if (doSave) {
+            SignShop.log("AllowCommaDecimalSeparator has been updated to " + state.name, Level.INFO);
+            FileConfiguration ymlThing = configUtil.loadYMLFromPluginFolder(configFilename);
+            File configFile = new File(SignShop.getInstance().getDataFolder(), configFilename);
+            ymlThing.set("AllowCommaDecimalSeparator", state.name);
+            saveConfig(ymlThing, configFile);
+        }
+    }
+    public static void setAllowCommaDecimalSeparator(CommaDecimalSeparatorState state) {
+        setAllowCommaDecimalSeparator(state, true);
+    }
 
     public static Material getLinkMaterial() {
         return linkMaterial;

--- a/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
@@ -32,9 +32,9 @@ public class economyUtil {
         StringBuilder sPrice = new StringBuilder();
         Double fPrice;
         for(int i = 0; i < priceline.length(); i++)
-            if(Character.isDigit(priceline.charAt(i)) || priceline.charAt(i) == '.' || (SignShopConfig.allowCommaDecimalSeperator() && priceline.charAt(i) == ','))
+            if(Character.isDigit(priceline.charAt(i)) || priceline.charAt(i) == '.' || (SignShopConfig.allowCommaDecimalSeparator().isPermitted() && priceline.charAt(i) == ','))
                 sPrice.append(priceline.charAt(i));
-        if (SignShopConfig.allowCommaDecimalSeperator()) return parsePriceInternational(sPrice.toString());
+        if (SignShopConfig.allowCommaDecimalSeparator().isPermitted()) return parsePriceInternational(sPrice.toString());
         try {
             fPrice = Double.parseDouble(sPrice.toString());
         }
@@ -89,55 +89,55 @@ public class economyUtil {
                 // There are delimiters, determine what kind
 
                 /*
-                    If the comma comes last, and there is only one comma, it is *probably* comma seperated
-                        Sidenote: it doesn't matter if not actually comma seperated, the parser will fix that later
-                    If there are no commas and more than one period, it has to be a comma seperated number
-                        A comma seperated number cannot be valid with more than one comma,
-                        the same way that a period seperated number cannot be valid with more than one period.
+                    If the comma comes last, and there is only one comma, it is *probably* comma separated
+                        Sidenote: it doesn't matter if not actually comma separated, the parser will fix that later
+                    If there are no commas and more than one period, it has to be a comma separated number
+                        A comma separated number cannot be valid with more than one comma,
+                        the same way that a period separated number cannot be valid with more than one period.
 
-                    This method does not select a guess that is theoretically impossible (contains more than one decimal seperator),
-                    although it will default to attempting to parse a period seperated number
+                    This method does not select a guess that is theoretically impossible (contains more than one decimal separator),
+                    although it will default to attempting to parse a period separated number
                 */
-                boolean likelyCommaSeperated = (lastComma > lastPeriod && totalCommas == 1) || (totalCommas == 0 && totalPeriods > 1);
+                boolean likelyCommaSeparated = (lastComma > lastPeriod && totalCommas == 1) || (totalCommas == 0 && totalPeriods > 1);
 
-                SignShop.debugMessage("Likely: " + (likelyCommaSeperated ? "COMMA SEPERATED" : "PERIOD SEPERATED"));
+                SignShop.debugMessage("Likely: " + (likelyCommaSeparated ? "COMMA SEPARATED" : "PERIOD SEPARATED"));
 
                 /*
                     Start of String
-                    Group 1- All digits and divisions up to a decimal seperator
-                    NCG- A single decimal seperator
+                    Group 1- All digits and divisions up to a decimal separator
+                    NCG- A single decimal separator
                       Group 2- 2 digits after the decimals
                     End of String
 
                     These regexs must match the ENTIRE string. If a complete match is not found it is considered invalid.
-                    This ensures that there is only one decimal seperator. Having 2+ is not valid
+                    This ensures that there is only one decimal separator. Having 2+ is not valid
 
-                    Period-seperated Parser uses ',' as a division, and '.' as a decimal seperator
-                    Comma-seperated Parser uses '.' as a division, and ',' as a decimal seperator
+                    Period-separated Parser uses ',' as a division, and '.' as a decimal separator
+                    Comma-separated Parser uses '.' as a division, and ',' as a decimal separator
                  */
-                Matcher periodSeperatedParser = Pattern.compile("^([\\d,]*+)(?:[.](\\d{0,2}))?$").matcher(price);
-                Matcher commaSeperatedParser = Pattern.compile("^([\\d.]*+)(?:[,](\\d{0,2}))?$").matcher(price);
+                Matcher periodSeparatedParser = Pattern.compile("^([\\d,]*+)(?:[.](\\d{0,2}))?$").matcher(price);
+                Matcher commaSeparatedParser = Pattern.compile("^([\\d.]*+)(?:[,](\\d{0,2}))?$").matcher(price);
 
-                String periodSeperatedString = periodSeperatedParser.matches() ? price.replace(",", "") : null;
-                String commaSeperatedString = commaSeperatedParser.matches() ? price.replace(".", "").replace(",", ".") : null;
+                String periodSeparatedString = periodSeparatedParser.matches() ? price.replace(",", "") : null;
+                String commaSeparatedString = commaSeparatedParser.matches() ? price.replace(".", "").replace(",", ".") : null;
 
                 String priceString = null;
 
-                if (likelyCommaSeperated && commaSeperatedString != null) {
-                    // If the price was guessed to be comma-seperated and the comma-seperated regex passed, its comma-seperated
-                    SignShop.debugMessage("Actual: COMMA SEPERATED");
-                    priceString = commaSeperatedString;
-                } else if (periodSeperatedString != null) {
-                    // If the price was guessed to be period-seperated or the comma-seperated regex failed
-                    // AND the period-seperated regex passed, its period-seperated
-                    SignShop.debugMessage("Actual: PERIOD SEPERATED");
-                    priceString = periodSeperatedString;
+                if (likelyCommaSeparated && commaSeparatedString != null) {
+                    // If the price was guessed to be comma-separated and the comma-separated regex passed, its comma-separated
+                    SignShop.debugMessage("Actual: COMMA SEPARATED");
+                    priceString = commaSeparatedString;
+                } else if (periodSeparatedString != null) {
+                    // If the price was guessed to be period-separated or the comma-separated regex failed
+                    // AND the period-separated regex passed, its period-separated
+                    SignShop.debugMessage("Actual: PERIOD SEPARATED");
+                    priceString = periodSeparatedString;
                 } else {
                     // If the price has not yet been parsed, attempt error correction
-                    if (!likelyCommaSeperated && commaSeperatedString != null) {
-                        // Detection made a mistake, price was guessed as period-seperated, but the period-seperated regex failed and the comma-seperated passed. Its comma-seperated
-                        SignShop.debugMessage("Actual: COMMA SEPERATED");
-                        priceString = commaSeperatedString;
+                    if (!likelyCommaSeparated && commaSeparatedString != null) {
+                        // Detection made a mistake, price was guessed as period-separated, but the period-separated regex failed and the comma-separated passed. Its comma-separated
+                        SignShop.debugMessage("Actual: COMMA SEPARATED");
+                        priceString = commaSeparatedString;
                     } else {
                         // No valid match could be parsed
                         SignShop.debugMessage("Actual: INVALID");

--- a/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
@@ -1,8 +1,12 @@
 package org.wargamer2010.signshop.util;
 
 import org.bukkit.ChatColor;
+import org.wargamer2010.signshop.SignShop;
 import org.wargamer2010.signshop.Vault;
 import org.wargamer2010.signshop.configuration.SignShopConfig;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class economyUtil {
 
@@ -24,6 +28,7 @@ public class economyUtil {
     public static double parsePrice(String line) {
         if(line == null)
             return 0.0d;
+        if (SignShopConfig.useInternationalCurrencyParser()) return parsePriceInternational(line);
         String priceline = ChatColor.stripColor(line);
         StringBuilder sPrice = new StringBuilder();
         Double fPrice;
@@ -42,6 +47,138 @@ public class economyUtil {
         if(Double.isNaN(fPrice) || fPrice.isInfinite())
             fPrice = 0.0d;
         return fPrice;
+    }
+
+    public static double parsePriceInternational(String line) {
+        if (SignShopConfig.debugging()) SignShop.debugMessage("Parsing a price from '" + line + "'");
+        /*
+            Start of String
+            NCG- All non-numeric characters up to the first digit
+            Capture Group- All sequential numerals, commas, periods, and spaces
+            NCG- Any characters after the price (having a group of numerals seperated from the price will cause the method to fail)
+        */
+        Matcher priceFinder = Pattern.compile("^[\\D]*+([\\d\\s,.]*+)[\\D]*+$").matcher(ChatColor.stripColor(line));
+
+        if (!priceFinder.matches()) {
+            if (SignShopConfig.debugging()) SignShop.debugMessage(line + " does not contain a valid price");
+            return 0.0d;
+        }
+
+        // Get the captured price from the regex
+        String price = priceFinder.group(1);
+
+        if (price == null || price.equals("")) {
+            if (SignShopConfig.debugging()) SignShop.debugMessage(line + " does not contain a price");
+            return 0.0d;
+        }
+        // Strip out spaces
+        else price = price.replace(" ", "");
+
+        if (SignShopConfig.debugging()) SignShop.debugMessage("Detected price: " + price);
+
+        // Count the number, and last known position of each type of delimiter
+        Matcher periodFinder = Pattern.compile("[.]").matcher(price);
+        Matcher commaFinder = Pattern.compile("[,]").matcher(price);
+
+        int totalPeriods = 0;
+        int lastPeriod = 0;
+        int totalCommas = 0;
+        int lastComma = 0;
+
+        while (periodFinder.find()) {
+            lastPeriod = periodFinder.start();
+            totalPeriods++;
+        }
+        while (commaFinder.find()) {
+            lastComma = commaFinder.start();
+            totalCommas++;
+        }
+
+        // Now, the fun begins.
+
+        double parsedPrice;
+
+        try {
+
+            if (totalPeriods == 0 && totalCommas == 0) {
+                // If there are no delimiters, just parse the price
+                if (SignShopConfig.debugging()) SignShop.debugMessage(price + " is not delimited");
+                parsedPrice = Double.parseDouble(price);
+            } else {
+                // There are delimiters, determine what kind
+
+            /*
+                If the comma comes last, and there is only one comma, it is *probably* international
+                    Sidenote: it doesn't matter if not actually comma delimited, the parser will fix that later
+                If there are no commas and more than one period, it has to be an international number
+                    An internation number cannot be valid with more than one comma,
+                    the same way that a US number cannot be valid with more than one period.
+
+                This method does not select a guess that is theoretically impossible (contains more than one decimal seperator),
+                although it will default to attempting to parse a US delimited number
+            */
+                boolean likelyInternational = (lastComma > lastPeriod && totalCommas == 1) || (totalCommas == 0 && totalPeriods > 1);
+
+                if (SignShopConfig.debugging())
+                    SignShop.debugMessage("Likely: " + (likelyInternational ? "INTERNATIONAL" : "NOT INTERNATIONAL"));
+
+            /*
+                Start of String
+                Group 1- All digits and divisions up to a decimal seperator
+                NCG- A single decimal seperator
+                  Group 2- 2 digits after the decimals
+                End of String
+
+                These regexs must match the ENTIRE string. If a complete match is not found it is considered invalid.
+                This ensures that there is only one decimal seperator. Having 2+ is not valid
+
+                US Parser uses ',' as a division, and '.' as a decimal seperator
+                EU Parser uses '.' as a division, and ',' as a decimal seperator
+             */
+                Matcher usParser = Pattern.compile("^([\\d,]*+)(?:[.](\\d{0,2}))?$").matcher(price);
+                Matcher euParser = Pattern.compile("^([\\d.]*+)(?:[,](\\d{0,2}))?$").matcher(price);
+
+                String usPriceString = usParser.matches() ? price.replace(",", "") : null;
+                String euPriceString = euParser.matches() ? price.replace(".", "").replace(",", ".") : null;
+
+                String priceString = null;
+
+                if (likelyInternational && euPriceString != null) {
+                    // If the price was guessed to be international and the EU regex passed, its international
+                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INTERNATIONAL");
+                    priceString = euPriceString;
+                } else if (usPriceString != null) {
+                    // If the price was guessed to be not international or the EU regex failed
+                    // AND the US regex passed, its US
+                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: NOT INTERNATIONAL");
+                    priceString = usPriceString;
+                }
+
+                if (priceString == null) {
+                    // If the price has not yet been parsed, attempt error correction
+                    if (!likelyInternational && euPriceString != null) {
+                        // Detection made a mistake, price was guessed as non-international, but the US regex failed and the EU passed. Its international
+                        if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INTERNATIONAL");
+                        priceString = euPriceString;
+                    } else {
+                        // No valid match could be parsed
+                        if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INVALID");
+                    }
+                }
+
+                // Attempt to parse the price
+                parsedPrice = priceString != null ? Double.parseDouble(priceString) : 0.0D;
+            }
+        } catch(NumberFormatException nFE) {
+            // something was wrong... don't even ask what cause I don't know
+            parsedPrice = 0.0d;
+        }
+
+        // Normalize
+        if(parsedPrice < 0.0d) parsedPrice = 0.0d;
+        if(Double.isNaN(parsedPrice) || Double.isInfinite(parsedPrice)) parsedPrice = 0.0d;
+
+        return parsedPrice;
     }
 
 }

--- a/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
@@ -28,13 +28,13 @@ public class economyUtil {
     public static double parsePrice(String line) {
         if(line == null)
             return 0.0d;
-        if (SignShopConfig.useInternationalCurrencyParser()) return parsePriceInternational(line);
         String priceline = ChatColor.stripColor(line);
         StringBuilder sPrice = new StringBuilder();
         Double fPrice;
         for(int i = 0; i < priceline.length(); i++)
-            if(Character.isDigit(priceline.charAt(i)) || priceline.charAt(i) == '.')
+            if(Character.isDigit(priceline.charAt(i)) || priceline.charAt(i) == '.' || (SignShopConfig.allowCommaDecimalSeperator() && priceline.charAt(i) == ','))
                 sPrice.append(priceline.charAt(i));
+        if (SignShopConfig.allowCommaDecimalSeperator()) return parsePriceInternational(sPrice.toString());
         try {
             fPrice = Double.parseDouble(sPrice.toString());
         }
@@ -49,32 +49,13 @@ public class economyUtil {
         return fPrice;
     }
 
-    public static double parsePriceInternational(String line) {
-        if (SignShopConfig.debugging()) SignShop.debugMessage("Parsing a price from '" + line + "'");
-        /*
-            Start of String
-            NCG- All non-numeric characters up to the first digit
-            Capture Group- All sequential numerals, commas, periods, and spaces
-            NCG- Any characters after the price (having a group of numerals seperated from the price will cause the method to fail)
-        */
-        Matcher priceFinder = Pattern.compile("^[\\D]*+([\\d\\s,.]*+)[\\D]*+$").matcher(ChatColor.stripColor(line));
-
-        if (!priceFinder.matches()) {
-            if (SignShopConfig.debugging()) SignShop.debugMessage(line + " does not contain a valid price");
-            return 0.0d;
-        }
-
-        // Get the captured price from the regex
-        String price = priceFinder.group(1);
+    private static double parsePriceInternational(String price) {
+        if (SignShopConfig.debugging()) SignShop.debugMessage("Parsing a price from '" + price + "'");
 
         if (price == null || price.equals("")) {
-            if (SignShopConfig.debugging()) SignShop.debugMessage(line + " does not contain a price");
+            if (SignShopConfig.debugging()) SignShop.debugMessage("Empty! (no price found)");
             return 0.0d;
         }
-        // Strip out spaces
-        else price = price.replace(" ", "");
-
-        if (SignShopConfig.debugging()) SignShop.debugMessage("Detected price: " + price);
 
         // Count the number, and last known position of each type of delimiter
         Matcher periodFinder = Pattern.compile("[.]").matcher(price);
@@ -108,19 +89,19 @@ public class economyUtil {
                 // There are delimiters, determine what kind
 
             /*
-                If the comma comes last, and there is only one comma, it is *probably* international
-                    Sidenote: it doesn't matter if not actually comma delimited, the parser will fix that later
-                If there are no commas and more than one period, it has to be an international number
-                    An internation number cannot be valid with more than one comma,
-                    the same way that a US number cannot be valid with more than one period.
+                If the comma comes last, and there is only one comma, it is *probably* comma seperated
+                    Sidenote: it doesn't matter if not actually comma seperated, the parser will fix that later
+                If there are no commas and more than one period, it has to be a comma seperated number
+                    A comma seperated number cannot be valid with more than one comma,
+                    the same way that a period seperated number cannot be valid with more than one period.
 
                 This method does not select a guess that is theoretically impossible (contains more than one decimal seperator),
-                although it will default to attempting to parse a US delimited number
+                although it will default to attempting to parse a period seperated number
             */
-                boolean likelyInternational = (lastComma > lastPeriod && totalCommas == 1) || (totalCommas == 0 && totalPeriods > 1);
+                boolean likelyCommaSeperated = (lastComma > lastPeriod && totalCommas == 1) || (totalCommas == 0 && totalPeriods > 1);
 
                 if (SignShopConfig.debugging())
-                    SignShop.debugMessage("Likely: " + (likelyInternational ? "INTERNATIONAL" : "NOT INTERNATIONAL"));
+                    SignShop.debugMessage("Likely: " + (likelyCommaSeperated ? "COMMA SEPERATED" : "PERIOD SEPERATED"));
 
             /*
                 Start of String
@@ -132,34 +113,32 @@ public class economyUtil {
                 These regexs must match the ENTIRE string. If a complete match is not found it is considered invalid.
                 This ensures that there is only one decimal seperator. Having 2+ is not valid
 
-                US Parser uses ',' as a division, and '.' as a decimal seperator
-                EU Parser uses '.' as a division, and ',' as a decimal seperator
+                Period-seperated Parser uses ',' as a division, and '.' as a decimal seperator
+                Comma-seperated Parser uses '.' as a division, and ',' as a decimal seperator
              */
-                Matcher usParser = Pattern.compile("^([\\d,]*+)(?:[.](\\d{0,2}))?$").matcher(price);
-                Matcher euParser = Pattern.compile("^([\\d.]*+)(?:[,](\\d{0,2}))?$").matcher(price);
+                Matcher periodSeperatedParser = Pattern.compile("^([\\d,]*+)(?:[.](\\d{0,2}))?$").matcher(price);
+                Matcher commaSeperatedParser = Pattern.compile("^([\\d.]*+)(?:[,](\\d{0,2}))?$").matcher(price);
 
-                String usPriceString = usParser.matches() ? price.replace(",", "") : null;
-                String euPriceString = euParser.matches() ? price.replace(".", "").replace(",", ".") : null;
+                String periodSeperatedString = periodSeperatedParser.matches() ? price.replace(",", "") : null;
+                String commaSeperatedString = commaSeperatedParser.matches() ? price.replace(".", "").replace(",", ".") : null;
 
                 String priceString = null;
 
-                if (likelyInternational && euPriceString != null) {
-                    // If the price was guessed to be international and the EU regex passed, its international
-                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INTERNATIONAL");
-                    priceString = euPriceString;
-                } else if (usPriceString != null) {
-                    // If the price was guessed to be not international or the EU regex failed
-                    // AND the US regex passed, its US
-                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: NOT INTERNATIONAL");
-                    priceString = usPriceString;
-                }
-
-                if (priceString == null) {
+                if (likelyCommaSeperated && commaSeperatedString != null) {
+                    // If the price was guessed to be comma-seperated and the comma-seperated regex passed, its comma-seperated
+                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: COMMA SEPERATED");
+                    priceString = commaSeperatedString;
+                } else if (periodSeperatedString != null) {
+                    // If the price was guessed to be period-seperated or the comma-seperated regex failed
+                    // AND the period-seperated regex passed, its period-seperated
+                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: PERIOD SEPERATED");
+                    priceString = periodSeperatedString;
+                } else {
                     // If the price has not yet been parsed, attempt error correction
-                    if (!likelyInternational && euPriceString != null) {
-                        // Detection made a mistake, price was guessed as non-international, but the US regex failed and the EU passed. Its international
-                        if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INTERNATIONAL");
-                        priceString = euPriceString;
+                    if (!likelyCommaSeperated && commaSeperatedString != null) {
+                        // Detection made a mistake, price was guessed as period-seperated, but the period-seperated regex failed and the comma-seperated passed. Its comma-seperated
+                        if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: COMMA SEPERATED");
+                        priceString = commaSeperatedString;
                     } else {
                         // No valid match could be parsed
                         if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INVALID");
@@ -175,8 +154,7 @@ public class economyUtil {
         }
 
         // Normalize
-        if(parsedPrice < 0.0d) parsedPrice = 0.0d;
-        if(Double.isNaN(parsedPrice) || Double.isInfinite(parsedPrice)) parsedPrice = 0.0d;
+        if(parsedPrice < 0.0d || Double.isNaN(parsedPrice) || Double.isInfinite(parsedPrice)) parsedPrice = 0.0d;
 
         return parsedPrice;
     }

--- a/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
@@ -50,10 +50,10 @@ public class economyUtil {
     }
 
     private static double parsePriceInternational(String price) {
-        if (SignShopConfig.debugging()) SignShop.debugMessage("Parsing a price from '" + price + "'");
+        SignShop.debugMessage("Parsing a price from '" + price + "'");
 
         if (price == null || price.equals("")) {
-            if (SignShopConfig.debugging()) SignShop.debugMessage("Empty! (no price found)");
+            SignShop.debugMessage("Empty! (no price found)");
             return 0.0d;
         }
 
@@ -83,39 +83,38 @@ public class economyUtil {
 
             if (totalPeriods == 0 && totalCommas == 0) {
                 // If there are no delimiters, just parse the price
-                if (SignShopConfig.debugging()) SignShop.debugMessage(price + " is not delimited");
+                SignShop.debugMessage(price + " is not delimited");
                 parsedPrice = Double.parseDouble(price);
             } else {
                 // There are delimiters, determine what kind
 
-            /*
-                If the comma comes last, and there is only one comma, it is *probably* comma seperated
-                    Sidenote: it doesn't matter if not actually comma seperated, the parser will fix that later
-                If there are no commas and more than one period, it has to be a comma seperated number
-                    A comma seperated number cannot be valid with more than one comma,
-                    the same way that a period seperated number cannot be valid with more than one period.
+                /*
+                    If the comma comes last, and there is only one comma, it is *probably* comma seperated
+                        Sidenote: it doesn't matter if not actually comma seperated, the parser will fix that later
+                    If there are no commas and more than one period, it has to be a comma seperated number
+                        A comma seperated number cannot be valid with more than one comma,
+                        the same way that a period seperated number cannot be valid with more than one period.
 
-                This method does not select a guess that is theoretically impossible (contains more than one decimal seperator),
-                although it will default to attempting to parse a period seperated number
-            */
+                    This method does not select a guess that is theoretically impossible (contains more than one decimal seperator),
+                    although it will default to attempting to parse a period seperated number
+                */
                 boolean likelyCommaSeperated = (lastComma > lastPeriod && totalCommas == 1) || (totalCommas == 0 && totalPeriods > 1);
 
-                if (SignShopConfig.debugging())
-                    SignShop.debugMessage("Likely: " + (likelyCommaSeperated ? "COMMA SEPERATED" : "PERIOD SEPERATED"));
+                SignShop.debugMessage("Likely: " + (likelyCommaSeperated ? "COMMA SEPERATED" : "PERIOD SEPERATED"));
 
-            /*
-                Start of String
-                Group 1- All digits and divisions up to a decimal seperator
-                NCG- A single decimal seperator
-                  Group 2- 2 digits after the decimals
-                End of String
+                /*
+                    Start of String
+                    Group 1- All digits and divisions up to a decimal seperator
+                    NCG- A single decimal seperator
+                      Group 2- 2 digits after the decimals
+                    End of String
 
-                These regexs must match the ENTIRE string. If a complete match is not found it is considered invalid.
-                This ensures that there is only one decimal seperator. Having 2+ is not valid
+                    These regexs must match the ENTIRE string. If a complete match is not found it is considered invalid.
+                    This ensures that there is only one decimal seperator. Having 2+ is not valid
 
-                Period-seperated Parser uses ',' as a division, and '.' as a decimal seperator
-                Comma-seperated Parser uses '.' as a division, and ',' as a decimal seperator
-             */
+                    Period-seperated Parser uses ',' as a division, and '.' as a decimal seperator
+                    Comma-seperated Parser uses '.' as a division, and ',' as a decimal seperator
+                 */
                 Matcher periodSeperatedParser = Pattern.compile("^([\\d,]*+)(?:[.](\\d{0,2}))?$").matcher(price);
                 Matcher commaSeperatedParser = Pattern.compile("^([\\d.]*+)(?:[,](\\d{0,2}))?$").matcher(price);
 
@@ -126,22 +125,22 @@ public class economyUtil {
 
                 if (likelyCommaSeperated && commaSeperatedString != null) {
                     // If the price was guessed to be comma-seperated and the comma-seperated regex passed, its comma-seperated
-                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: COMMA SEPERATED");
+                    SignShop.debugMessage("Actual: COMMA SEPERATED");
                     priceString = commaSeperatedString;
                 } else if (periodSeperatedString != null) {
                     // If the price was guessed to be period-seperated or the comma-seperated regex failed
                     // AND the period-seperated regex passed, its period-seperated
-                    if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: PERIOD SEPERATED");
+                    SignShop.debugMessage("Actual: PERIOD SEPERATED");
                     priceString = periodSeperatedString;
                 } else {
                     // If the price has not yet been parsed, attempt error correction
                     if (!likelyCommaSeperated && commaSeperatedString != null) {
                         // Detection made a mistake, price was guessed as period-seperated, but the period-seperated regex failed and the comma-seperated passed. Its comma-seperated
-                        if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: COMMA SEPERATED");
+                        SignShop.debugMessage("Actual: COMMA SEPERATED");
                         priceString = commaSeperatedString;
                     } else {
                         // No valid match could be parsed
-                        if (SignShopConfig.debugging()) SignShop.debugMessage("Actual: INVALID");
+                        SignShop.debugMessage("Actual: INVALID");
                     }
                 }
 
@@ -155,6 +154,8 @@ public class economyUtil {
 
         // Normalize
         if(parsedPrice < 0.0d || Double.isNaN(parsedPrice) || Double.isInfinite(parsedPrice)) parsedPrice = 0.0d;
+
+        SignShop.debugMessage("Parsed price: " + parsedPrice);
 
         return parsedPrice;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,7 +31,8 @@ MetricsEnabled: true
 Debugging: false
 
 # Use an internationally compatible currency parser that supports ',' and '.' decimal separators.  This may, but likely will not be, incompatible with existing servers.
-AllowCommaDecimalSeperator: false
+# This will be automatically enabled on new servers, and disabled for servers that have existing shops
+AllowCommaDecimalSeparator: auto
 
 #----------- Tools ------------------
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,8 +30,8 @@ MetricsEnabled: true
 # Should verbose debugging messages be enabled? This could get very spammy or it may do nothing.
 Debugging: false
 
-# Use an internationally compatible currency parser that supports ',' and '.' decimal separators.  This may, but likely will not be, incompatible with existing servers since it limits to 2 decimal places.
-UseInternationalCurrencyParser: false
+# Use an internationally compatible currency parser that supports ',' and '.' decimal separators.  This may, but likely will not be, incompatible with existing servers.
+AllowCommaDecimalSeperator: false
 
 #----------- Tools ------------------
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,6 +30,9 @@ MetricsEnabled: true
 # Should verbose debugging messages be enabled? This could get very spammy or it may do nothing.
 Debugging: false
 
+# Use an internationally compatible currency parser that supports ',' and '.' decimal separators.  This may, but likely will not be, incompatible with existing servers since it limits to 2 decimal places.
+UseInternationalCurrencyParser: false
+
 #----------- Tools ------------------
 
 # Item names (https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html)

--- a/src/test/java/org/wargamer2010/signshop/util/economyUtilTest.java
+++ b/src/test/java/org/wargamer2010/signshop/util/economyUtilTest.java
@@ -1,0 +1,67 @@
+package org.wargamer2010.signshop.util;
+
+import junit.framework.TestCase;
+import org.wargamer2010.signshop.configuration.SignShopConfig;
+
+public class economyUtilTest extends TestCase {
+    /**
+     * Test the international price parser.
+     */
+    public void testparsePrice() {
+        SignShopConfig.CommaDecimalSeparatorState prev = SignShopConfig.allowCommaDecimalSeparator();
+        SignShopConfig.setAllowCommaDecimalSeparator(SignShopConfig.CommaDecimalSeparatorState.TRUE, false);
+        assertEquals(0.0D, economyUtil.parsePrice(null));
+        assertEquals(0.0D, economyUtil.parsePrice("null"));
+        assertEquals(0.0D, economyUtil.parsePrice("NaN"));
+        assertEquals(5.0D, economyUtil.parsePrice("-5"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1234"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1234.00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1234,00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1,234.00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1.234,00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1 234.00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1 234,00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1, 234.00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1. 234,00"));
+        assertEquals(123400.0D, economyUtil.parsePrice("1, 234,00"));
+        assertEquals(123400.0D, economyUtil.parsePrice("1. 234.00"));
+        assertEquals(123400.0D, economyUtil.parsePrice("1. 234. 00"));
+        assertEquals(123400.0D, economyUtil.parsePrice("1, 234, 00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1234"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1234 wa"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1234.00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1234,00"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1234.00 wa"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1234,00 wa"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1,234 wa"));
+        assertEquals(1234.0D, economyUtil.parsePrice("wa 1.234 wa"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1,,,,,234"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1.....234"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1,2,3,4,,,"));
+        assertEquals(1234.0D, economyUtil.parsePrice("1.2.3.4..."));
+        assertEquals(1234.0D, economyUtil.parsePrice(",,,1,2,3,4"));
+        assertEquals(1234.0D, economyUtil.parsePrice("...1.2.3.4"));
+        assertEquals(0.0D, economyUtil.parsePrice("..,.,.,.1234,.,.,.,"));
+        assertEquals(0.0D, economyUtil.parsePrice("1,.2,.3,.4,."));
+        assertEquals(0.0D, economyUtil.parsePrice("1.,2.,3.,4.,"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("wa 1234 wa 1234"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("1234 wa 1234 wa"));
+        assertEquals(121212.0D, economyUtil.parsePrice("12 wa 12 wa 12 wa"));
+        assertEquals(121212.0D, economyUtil.parsePrice("wa 12 wa 12 wa 12"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("wa, 12,3,4 w,a 1,2,34,"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("1234. wa. 1.2.3.4 .wa."));
+        assertEquals(1212.12D, economyUtil.parsePrice("12. wa 12. wa, 12 wa"));
+        assertEquals(1212.12D, economyUtil.parsePrice("wa, 12, wa 1,2 wa. 12"));
+        assertEquals(0.0D, economyUtil.parsePrice("12. wa 1,2 wa 12 wa"));
+        assertEquals(0.0D, economyUtil.parsePrice("wa, 12, wa 1.2 wa 12"));
+        assertEquals(1234.0D, economyUtil.parsePrice("!@#$%^&*()1234!@#$%^&*()"));
+        assertEquals(0.0D, economyUtil.parsePrice(""));
+        assertEquals(0.0D, economyUtil.parsePrice("i am nothing"));
+        assertEquals(40711031.0D, economyUtil.parsePrice("i 4m n07h1ng w1th s0m3th1ng"));
+        assertEquals(43.0D, economyUtil.parsePrice("giggity goo ga 43"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("1234.1234"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("1234,1234"));
+        assertEquals(12341234.0D, economyUtil.parsePrice("1234+1234"));
+        SignShopConfig.setAllowCommaDecimalSeparator(prev, false);
+    }
+}


### PR DESCRIPTION
Updated currency parser that can process both ',' and '.' as a decimal separator for currency.

Config option 'AllowCommaDecimalSeparator' will default to 'true' on new servers with no shops, and 'false' on existing servers with shops that may not be compatible with the new parser