### PR TITLE
Add parsed price caching support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <version>1.7</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>4.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -70,6 +70,7 @@ public class SignShopConfig {
     private static boolean UseBlacklistAsWhitelist = false;
     private static boolean EnableWrittenBookFix = true;
     private static CommaDecimalSeparatorState AllowCommaDecimalSeparator = CommaDecimalSeparatorState.AUTO;
+    private static boolean CachePrices = true;
     private static String ColorCode = "&";
     private static String ChatPrefix = "&6[SignShop]";
     private static ChatColor TextColor = ChatColor.YELLOW;
@@ -245,6 +246,7 @@ public class SignShopConfig {
         UseBlacklistAsWhitelist = ymlThing.getBoolean("UseBlacklistAsWhitelist", UseBlacklistAsWhitelist);
         EnableWrittenBookFix = ymlThing.getBoolean("EnableWrittenBookFix", EnableWrittenBookFix);
         setAllowCommaDecimalSeparator(CommaDecimalSeparatorState.fromName(ymlThing.getString("AllowCommaDecimalSeparator", AllowCommaDecimalSeparator.name)));
+        CachePrices = ymlThing.getBoolean("CachePrices", CachePrices);
         ColorCode = ymlThing.getString("ColorCode", ColorCode);
         ChatPrefix = ymlThing.getString("ChatPrefix", ChatPrefix);
         Languages = ymlThing.getString("Languages", Languages);
@@ -852,6 +854,13 @@ public class SignShopConfig {
     }
     public static void setAllowCommaDecimalSeparator(CommaDecimalSeparatorState state) {
         setAllowCommaDecimalSeparator(state, true);
+    }
+
+    public static boolean CachePrices() {
+        return CachePrices;
+    }
+    public static void setCachePrices(boolean value) {
+        CachePrices = value;
     }
 
     public static Material getLinkMaterial() {

--- a/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/economyUtil.java
@@ -5,10 +5,13 @@ import org.wargamer2010.signshop.SignShop;
 import org.wargamer2010.signshop.Vault;
 import org.wargamer2010.signshop.configuration.SignShopConfig;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class economyUtil {
+    public static final Map<String, Double> priceCache = new HashMap<>();
 
     private economyUtil() {
 
@@ -28,13 +31,18 @@ public class economyUtil {
     public static double parsePrice(String line) {
         if(line == null)
             return 0.0d;
+        if (SignShopConfig.CachePrices() && priceCache.containsKey(line)) return priceCache.get(line);
         String priceline = ChatColor.stripColor(line);
         StringBuilder sPrice = new StringBuilder();
         Double fPrice;
         for(int i = 0; i < priceline.length(); i++)
             if(Character.isDigit(priceline.charAt(i)) || priceline.charAt(i) == '.' || (SignShopConfig.allowCommaDecimalSeparator().isPermitted() && priceline.charAt(i) == ','))
                 sPrice.append(priceline.charAt(i));
-        if (SignShopConfig.allowCommaDecimalSeparator().isPermitted()) return parsePriceInternational(sPrice.toString());
+        if (SignShopConfig.allowCommaDecimalSeparator().isPermitted()) {
+            double price = parsePriceInternational(sPrice.toString());
+            if (SignShopConfig.CachePrices()) priceCache.put(line, price);
+            return price;
+        }
         try {
             fPrice = Double.parseDouble(sPrice.toString());
         }
@@ -46,6 +54,8 @@ public class economyUtil {
         }
         if(Double.isNaN(fPrice) || fPrice.isInfinite())
             fPrice = 0.0d;
+
+        if (SignShopConfig.CachePrices()) priceCache.put(line, fPrice);
         return fPrice;
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,6 +34,11 @@ Debugging: false
 # This will be automatically enabled on new servers, and disabled for servers that have existing shops
 AllowCommaDecimalSeparator: auto
 
+# If the server should cache the parses prices for signs.
+# This slightly increases computation time per request, but greatly reduces computation time for repeated requests
+# Most useful on larger servers with many signs
+CachePrices: true
+
 #----------- Tools ------------------
 
 # Item names (https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html)

--- a/src/test/java/org/wargamer2010/signshop/util/economyUtilTest.java
+++ b/src/test/java/org/wargamer2010/signshop/util/economyUtilTest.java
@@ -3,6 +3,10 @@ package org.wargamer2010.signshop.util;
 import junit.framework.TestCase;
 import org.wargamer2010.signshop.configuration.SignShopConfig;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 public class economyUtilTest extends TestCase {
     /**
      * Test the international price parser.
@@ -63,5 +67,252 @@ public class economyUtilTest extends TestCase {
         assertEquals(12341234.0D, economyUtil.parsePrice("1234,1234"));
         assertEquals(12341234.0D, economyUtil.parsePrice("1234+1234"));
         SignShopConfig.setAllowCommaDecimalSeparator(prev, false);
+    }
+
+    public void testPriceCaching() {
+        int testSize = 3000000, runs = 5;
+        runParserCacheTests(false, testSize, runs);
+        runParserCacheTests(true, testSize, runs);
+    }
+
+    public void runParserCacheTests(boolean oldParser, int testSize, int runs) {
+        System.out.println("Parser  : " + (oldParser ? "UNITED STATES" : "INTERNATIONAL"));
+        System.out.println("Data set: " + testSize + " price(s)");
+        System.out.println("Runs    : " + runs);
+
+        // Set up the correct parser
+        SignShopConfig.CommaDecimalSeparatorState state = SignShopConfig.allowCommaDecimalSeparator();
+        if (oldParser) SignShopConfig.setAllowCommaDecimalSeparator(SignShopConfig.CommaDecimalSeparatorState.FALSE, false);
+        else SignShopConfig.setAllowCommaDecimalSeparator(SignShopConfig.CommaDecimalSeparatorState.TRUE, false);
+
+        // Data storage for run statistics
+        List<PriceCacheTestData> runData = new ArrayList<>();
+
+        /*
+        Generate Input Data
+         */
+
+        String[] testData = new String[testSize];
+        for (int i = 0; i < testData.length; i++) testData[i] = randomPriceString();
+
+        /*
+        Run the parser and collect data
+         */
+        for (int run = 0; run < runs; run++) {
+            System.out.println("Executing: Run " + (run + 1) + " / " + runs);
+
+            // Clear the cache
+            economyUtil.priceCache.clear();
+
+            // Data variables
+            long timePriceParseBegin, timePriceParseEnd,
+                    timePriceParseCacheBegin, timePriceParseCacheEnd,
+                    timeCacheHitBegin, timeCacheHitEnd;
+            long cacheSize;
+
+            /*
+            Parse Data, no cache
+             */
+
+            // Time before parsing
+            timePriceParseBegin = System.currentTimeMillis();
+
+            double[] parsed = parsePrices(testData, false);
+
+            // Time after parsing
+            timePriceParseEnd = System.currentTimeMillis();
+
+            /*
+            Parse data, with cache
+             */
+
+            // Measure memory before data is parsed with cache
+            long preParseCacheMemory = usedMemory();
+
+            // Time before parsing with cache
+            timePriceParseCacheBegin = System.currentTimeMillis();
+
+            parsePrices(testData, true);
+
+            // Time after parsing
+            timePriceParseCacheEnd = System.currentTimeMillis();
+
+            // Measure memory after data is parsed with cache
+            cacheSize = usedMemory() - preParseCacheMemory;
+
+            /*
+            Hit the cached data
+             */
+
+            // Time before hitting cache
+            timeCacheHitBegin = System.currentTimeMillis();
+
+            parsePrices(testData, true);
+
+            // Time after cache hit
+            timeCacheHitEnd = System.currentTimeMillis();
+
+            /*
+            Test is complete
+             */
+            runData.add(new PriceCacheTestData(timePriceParseBegin, timePriceParseEnd,
+                    timePriceParseCacheBegin, timePriceParseCacheEnd,
+                    timeCacheHitBegin, timeCacheHitEnd,
+                    cacheSize));
+        }
+
+        SignShopConfig.setAllowCommaDecimalSeparator(state, false);
+
+        System.out.println("Aggregating data...");
+        Statistics parseTimes = statistics(runData.stream().mapToLong((data) -> data.timePriceParseEnd - data.timePriceParseBegin).toArray());
+        Statistics cachedParseTimes = statistics(runData.stream().mapToLong((data) -> data.timePriceParseCacheEnd - data.timePriceParseCacheBegin).toArray());
+        Statistics cacheHitTimes = statistics(runData.stream().mapToLong((data) -> data.timeCacheHitEnd - data.timeCacheHitBegin).toArray());
+        Statistics cacheSizes = statistics(runData.stream().mapToLong(PriceCacheTestData::getCacheSize).toArray());
+
+        System.out.println("Test Complete. Results:");
+        System.out.println();
+        System.out.println("Average time to parse prices (no cache)  : " + parseTimes.mean + "ms");
+        System.out.println("  Deviation                              : " + parseTimes.standardDeviation + "ms");
+        System.out.println();
+        System.out.println("Average time to parse prices (with cache): " + cachedParseTimes.mean + "ms");
+        System.out.println("  Deviation                              : " + cachedParseTimes.standardDeviation + "ms");
+        System.out.println();
+        System.out.println("Average time to hit cache                : " + cacheHitTimes.mean + "ms");
+        System.out.println("  Deviation                              : " + cacheHitTimes.standardDeviation + "ms");
+        System.out.println();
+        System.out.println("Average total cache size                 : " + cacheSizes.mean + "MB");
+        System.out.println("  Deviation                              : " + cacheSizes.standardDeviation + "MB");
+    }
+
+    /**
+     * Parse an array of prices
+     * @param prices The data to be parsed
+     * @param useCache If the cache should be used
+     * @return An array of parsed prices
+     */
+    private double[] parsePrices(String[] prices, boolean useCache) {
+        boolean prev = SignShopConfig.CachePrices();
+        SignShopConfig.setCachePrices(useCache);
+
+        double[] parsed = new double[prices.length];
+        for (int i = 0; i < prices.length; i++) {
+            parsed[i] = economyUtil.parsePrice(prices[i]);
+        }
+
+        SignShopConfig.setCachePrices(prev);
+
+        return parsed;
+    }
+
+    /**
+     * Random alphanumeric price string
+     * @return A 20-character alpha-numeric string
+     */
+    private String randomPriceString() {
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+        int targetStringLength = 20;
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+    /**
+     * Get amount of memory currently in use
+     * @return Used memory (in MB)
+     */
+    private long usedMemory() {
+        Runtime runtime = Runtime.getRuntime();
+        runtime.gc();
+        return (runtime.totalMemory() - runtime.freeMemory()) / 1000000;
+    }
+
+    /*
+    Data storage
+     */
+    static class PriceCacheTestData {
+        // Data variables
+        long timePriceParseBegin;
+        long timePriceParseEnd;
+        long timePriceParseCacheBegin;
+        long timePriceParseCacheEnd;
+        long timeCacheHitBegin;
+        long timeCacheHitEnd;
+        long cacheSize;
+
+        public long getTimePriceParseBegin() {
+            return timePriceParseBegin;
+        }
+
+        public long getTimePriceParseEnd() {
+            return timePriceParseEnd;
+        }
+
+        public long getTimePriceParseCacheBegin() {
+            return timePriceParseCacheBegin;
+        }
+
+        public long getTimePriceParseCacheEnd() {
+            return timePriceParseCacheEnd;
+        }
+
+        public long getTimeCacheHitBegin() {
+            return timeCacheHitBegin;
+        }
+
+        public long getTimeCacheHitEnd() {
+            return timeCacheHitEnd;
+        }
+
+        public long getCacheSize() {
+            return cacheSize;
+        }
+
+        PriceCacheTestData(long timePriceParseBegin, long timePriceParseEnd,
+                           long timePriceParseCacheBegin, long timePriceParseCacheEnd,
+                           long timeCacheHitBegin, long timeCacheHitEnd,
+                           long cacheSize) {
+            this.timePriceParseBegin = timePriceParseBegin;
+            this.timePriceParseEnd = timePriceParseEnd;
+            this.timePriceParseCacheBegin = timePriceParseCacheBegin;
+            this.timePriceParseCacheEnd = timePriceParseCacheEnd;
+            this.timeCacheHitBegin = timeCacheHitBegin;
+            this.timeCacheHitEnd = timeCacheHitEnd;
+            this.cacheSize = cacheSize;
+        }
+    }
+
+    /*
+    Statistics calculator
+     */
+
+    static class Statistics {
+        long mean, standardDeviation;
+
+        Statistics(long mean, long standardDeviation) {
+            this.mean = mean;
+            this.standardDeviation = standardDeviation;
+        }
+    }
+
+    private static Statistics statistics(long[] numArray) {
+        double sum = 0.0, standardDeviation = 0.0;
+        int length = numArray.length;
+
+        for (long num : numArray) {
+            sum += num;
+        }
+
+        double mean = sum / length;
+
+        for (long num : numArray) {
+            standardDeviation += Math.pow(num - mean, 2);
+        }
+
+        return new Statistics((long) mean, (long) Math.sqrt(standardDeviation / length));
     }
 }

--- a/src/test/java/org/wargamer2010/signshop/util/economyUtilTest.java
+++ b/src/test/java/org/wargamer2010/signshop/util/economyUtilTest.java
@@ -75,7 +75,7 @@ public class economyUtilTest extends TestCase {
         runParserCacheTests(true, testSize, runs);
     }
 
-    public void runParserCacheTests(boolean oldParser, int testSize, int runs) {
+    private void runParserCacheTests(boolean oldParser, int testSize, int runs) {
         System.out.println("Parser  : " + (oldParser ? "UNITED STATES" : "INTERNATIONAL"));
         System.out.println("Data set: " + testSize + " price(s)");
         System.out.println("Runs    : " + runs);
@@ -234,7 +234,7 @@ public class economyUtilTest extends TestCase {
     /*
     Data storage
      */
-    static class PriceCacheTestData {
+    private static class PriceCacheTestData {
         // Data variables
         long timePriceParseBegin;
         long timePriceParseEnd;
@@ -290,7 +290,7 @@ public class economyUtilTest extends TestCase {
     Statistics calculator
      */
 
-    static class Statistics {
+    private static class Statistics {
         long mean, standardDeviation;
 
         Statistics(long mean, long standardDeviation) {


### PR DESCRIPTION
Added a config option to cache parsed prices to marginally improve performance on larger servers with a large number of similar signs